### PR TITLE
Updated tests dataformat after first test implementations

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The main goal being consistent behaviour across clients.
 
 ## Format
 
-The testsuite provided multiple YAML testset files containing test defitions.
+The testsuite provided multiple YAML testset files containing test definitions.
 The data format of these files is described in the following chapters.
 
 ### Testset

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # testsuite
+
 testsuite for homie client libraries
 
 this is under early development
@@ -8,3 +9,56 @@ this is under early development
 This test suite is intended for coders who write homie compatible software to quickly get a solid set of tests to run against their implementations.
 
 The main goal being consistent behaviour across clients.
+
+## Format
+
+The testsuite provided multiple YAML testset files containing test defitions.
+The data format of these files is described in the following chapters.
+
+### Testset
+
+A YAML file containing a set of tests to be run. A testset contains the following fields:
+
+- **`description`** (required): A string providing a brief explanation of the testset and its contained tests.
+- **`tests`** (required): A list of `test` definitions (see next chapter)
+
+#### Example:
+
+```yaml
+description: validating boolean values
+
+tests:
+  - ...test definition ...
+  - ...test definition ...
+  - ...test definition ...
+```
+
+### Test
+
+Defines a specific test to be executed. A test consist of the following fields:
+
+- **`description`** (required): A string providing a brief explanation of the test case or the scenario it represents.
+- **`type`** (required): A string indicating the type of the property value or data being tested. Valid values are:
+  - propertyformat
+  - propertyvalueinteger
+  - propertyvalue
+  - homieid
+  - ...
+- **`definition`**(optional depending on `type`): The test definition (this can for example be a property, node or device descriptions).
+- **`input_data`**(optional depending on `type`): The input data provided for the test, which may be represented as a string or other formats, depending on the `type`.
+- **`output_data`**(optional depending on `type`): The expected result after processing the `input_data`. This field is typically represented in the correct data type (e.g., `integer` for an integer test).
+- **`valid`**(required): A boolean indicating whether the defined test is supposed to pass (true) or fail (false)
+
+#### Example
+
+Here’s an example of how the data looks in practice:
+
+```yaml
+description: Normal integer value without format works
+type: propertyvalueinteger
+definition:
+  datatype: integer
+input_data: "12"
+output_data: 12
+valid: true
+```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ Here’s an example of how the data looks in practice:
 
 ```yaml
 description: Normal integer value without format works
-type: propertyvalueinteger
+testtype: propertyvalueinteger
 definition:
   datatype: integer
 input_data: "12"

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ tests:
 Defines a specific test to be executed. A test consist of the following fields:
 
 - **`description`** (required): A string providing a brief explanation of the test case or the scenario it represents.
-- **`type`** (required): A string indicating the type of the property value or data being tested. Valid values are:
+- **`testtype`** (required): A string indicating the type of the property value or data being tested. Valid values are:
   - propertyformat
   - propertyvalueinteger
   - propertyvalue

--- a/homie5/formats/boolean.yml
+++ b/homie5/formats/boolean.yml
@@ -2,51 +2,74 @@ description: validating boolean formats
 
 tests:
   - description: proper format is accepted
-    type: boolean
-    format: 'off,on'
+    type: propertydescription
+    definition:
+      datatype: boolean
+      format: "off,on"
     valid: true
   - description: reverse format is accepted
-    type: boolean
-    format: 'on,off'
+    type: propertydescription
+    definition:
+      datatype: boolean
+      format: "on,off"
     valid: true
   - description: format is optional
-    type: boolean
+    type: propertydescription
+    definition:
+      datatype: boolean
     valid: true
   - description: empty strings are not allowed
-    type: boolean
-    format: 'off,'
+    type: propertydescription
+    definition:
+      datatype: boolean
+      format: "off,"
     valid: false
   - description: empty strings are not allowed
-    type: boolean
-    format: ',on'
+    type: propertydescription
+    definition:
+      datatype: boolean
+      format: ",on"
     valid: false
   - description: space is allowed
-    type: boolean
-    format: 'off, '
-    valid: false
+    type: propertydescription
+    definition:
+      datatype: boolean
+      format: "off, "
+    valid: true
   - description: space is allowed
-    type: boolean
-    format: ' ,on'
-    valid: false
+    type: propertydescription
+    definition:
+      datatype: boolean
+      format: " ,on"
+    valid: true
   - description: single entry is not allowed
-    type: boolean
-    format: 'on'
+    type: propertydescription
+    definition:
+      datatype: boolean
+      format: "on"
     valid: false
   - description: more than 2 entries are not allowed
-    type: boolean
-    format: 'on,off,between'
+    type: propertydescription
+    definition:
+      datatype: boolean
+      format: "on,off,between"
     valid: false
   - description: duplicate entries are not allowed
-    # this is not in the spec but makes sense?
-    type: boolean
-    format: 'on,on'
+    type: propertydescription
+    definition:
+      # this is not in the spec but makes sense?
+      datatype: boolean
+      format: "on,on"
     valid: false
   - description: anything allowed, as long a comma separated
-    type: boolean
-    format: '@**&#%&@&,     5454      '
+    type: propertydescription
+    definition:
+      datatype: boolean
+      format: "@**&#%&@&,     5454      "
     valid: true
   - description: utf-8 characters are allowed
-    type: boolean
-    format: '👍,👎'
+    type: propertydescription
+    definition:
+      datatype: boolean
+      format: "👍,👎"
     valid: true
-

--- a/homie5/values/boolean.yml
+++ b/homie5/values/boolean.yml
@@ -17,7 +17,7 @@ tests:
     type: propertyvalue
     definition:
       datatype: boolean
-    input_data: ""
+    input_data: "\x00"
     valid: false
   - description: uppercase true is not allowed
     type: propertyvalue

--- a/homie5/values/boolean.yml
+++ b/homie5/values/boolean.yml
@@ -2,69 +2,98 @@ description: validating boolean values
 
 tests:
   - description: Passes valid boolean values
-    type: boolean
-    value: 'true'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: "true"
     valid: true
   - description: Passes valid boolean values
-    type: boolean
-    value: 'false'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: "false"
     valid: true
   - description: an empty string is not valid
-    type: boolean
-    value: ''
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: ""
     valid: false
   - description: uppercase true is not allowed
-    type: boolean
-    value: 'TRUE'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: "TRUE"
     valid: false
   - description: uppercase false is not allowed
-    type: boolean
-    value: 'FALSE'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: "FALSE"
     valid: false
   - description: capitalcase is not allowed
-    type: boolean
-    value: 'True'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: "True"
     valid: false
   - description: capitalcase is not allowed
-    type: boolean
-    value: 'False'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: "False"
     valid: false
   - description: shorthand is not allowed
-    type: boolean
-    value: t
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: t
     valid: false
   - description: shorthand is not allowed
-    type: boolean
-    value: f
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: f
     valid: false
   - description: numeric string is not allowed
-    type: boolean
-    value: '1'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: "1"
     valid: false
   - description: numeric string is not allowed
-    type: boolean
-    value: '0'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+    input_data: "0"
     valid: false
 
   # validating values with format
   - description: with format booleans are accepted
-    type: boolean
-    value: 'true'
-    format: 'on,off'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+      format: "on,off"
+    input_data: "true"
     valid: true
   - description: with format booleans are accepted
-    type: boolean
-    value: 'false'
-    format: 'on,off'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+      format: "on,off"
+    input_data: "false"
     valid: true
   - description: with format labels are not accepted
-    type: boolean
-    value: 'on'
-    format: 'on,off'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+      format: "on,off"
+    input_data: "on"
     valid: false
   - description: with format labels are not accepted
-    type: boolean
-    value: 'off'
-    format: 'on,off'
+    type: propertyvalue
+    definition:
+      datatype: boolean
+      format: "on,off"
+    input_data: "off"
     valid: false
-

--- a/homie5/values/id.yml
+++ b/homie5/values/id.yml
@@ -1,115 +1,115 @@
 description: validating Homie-IDs
 tests:
   - description: Passes valid Homie-IDs
-    type: id
-    value: xxx
+    type: homieid
+    input_data: xxx
     valid: true
   - description: long IDs are allowed
-    type: id
-    value: >-
+    type: homieid
+    input_data: >-
       xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx-xxxxxxxxxx
     valid: true
   - description: uppercase is not allowed
-    type: id
-    value: XXX
+    type: homieid
+    input_data: XXX
     valid: false
   - description: dash is allowed
-    type: id
-    value: x-x
+    type: homieid
+    input_data: x-x
     valid: true
   - description: leading dash is allowed
-    type: id
-    value: '-x'
+    type: homieid
+    input_data: "-x"
     valid: true
   - description: trailing dash is allowed
-    type: id
-    value: x-
+    type: homieid
+    input_data: x-
     valid: true
   - description: only dashes is allowed
-    type: id
-    value: '-----'
+    type: homieid
+    input_data: "-----"
     valid: true
   - description: leading digit is allowed
-    type: id
-    value: 1x
+    type: homieid
+    input_data: 1x
     valid: true
   - description: trailing digit is allowed
-    type: id
-    value: x1
+    type: homieid
+    input_data: x1
     valid: true
   - description: leading digit is allowed
-    type: id
-    value: '1'
+    type: homieid
+    input_data: "1"
     valid: true
   - description: trailing digit is allowed
-    type: id
-    value: '1'
+    type: homieid
+    input_data: "1"
     valid: true
   - description: only digits is allowed
-    type: id
-    value: '12345'
+    type: homieid
+    input_data: "12345"
     valid: true
   - description: empty is not allowed
-    type: id
-    value: ''
+    type: homieid
+    input_data: ""
     valid: false
   - description: underscore is not allowed
-    type: id
-    value: x_x
+    type: homieid
+    input_data: x_x
     valid: false
   - description: space is not allowed
-    type: id
-    value: x x
+    type: homieid
+    input_data: x x
     valid: false
   - description: special character ! are not allowed
-    type: id
-    value: x!x
+    type: homieid
+    input_data: x!x
     valid: false
   - description: special character @ is not allowed
-    type: id
-    value: x@x
+    type: homieid
+    input_data: x@x
     valid: false
-  - description: 'special character # is not allowed'
-    type: id
-    value: 'x#x'
+  - description: "special character # is not allowed"
+    type: homieid
+    input_data: "x#x"
     valid: false
   - description: special character $ is not allowed
-    type: id
-    value: x$x
+    type: homieid
+    input_data: x$x
     valid: false
   - description: special character % is not allowed
-    type: id
-    value: x%x
+    type: homieid
+    input_data: x%x
     valid: false
   - description: special character ^ is not allowed
-    type: id
-    value: x^x
+    type: homieid
+    input_data: x^x
     valid: false
   - description: special character & is not allowed
-    type: id
-    value: x&x
+    type: homieid
+    input_data: x&x
     valid: false
   - description: special character * is not allowed
-    type: id
-    value: x*x
+    type: homieid
+    input_data: x*x
     valid: false
   - description: special character ( is not allowed
-    type: id
-    value: x(x
+    type: homieid
+    input_data: x(x
     valid: false
   - description: special character ) is not allowed
-    type: id
-    value: x)x
+    type: homieid
+    input_data: x)x
     valid: false
   - description: special character = is not allowed
-    type: id
-    value: x=x
+    type: homieid
+    input_data: x=x
     valid: false
   - description: special character + is not allowed
-    type: id
-    value: x+x
+    type: homieid
+    input_data: x+x
     valid: false
   - description: utf-8 characters are not allowed
-    type: id
-    value: '👍'
+    type: homieid
+    input_data: "👍"
     valid: false

--- a/homie5/values/integer.yml
+++ b/homie5/values/integer.yml
@@ -1,0 +1,26 @@
+description: validating boolean values
+
+tests:
+  - description: Normal integer value without format works
+    type: propertyvalueinteger
+    definition:
+      datatype: integer
+    input_data: "12"
+    output_data: 12
+    valid: true
+  - description: Rounded step for min max bounds works
+    type: propertyvalueinteger
+    definition:
+      datatype: integer
+      format: "0:10:2"
+    input_data: "9"
+    output_data: 10
+    valid: true
+  - description: Rounded step for max bounds works
+    type: propertyvalueinteger
+    definition:
+      datatype: integer
+      format: ":10:2"
+    input_data: "9"
+    output_data: 8
+    valid: true


### PR DESCRIPTION
@Tieske Please have a look at these changes.
I did a brief implementation of the following 3 tests:
 - HomieID - parsing homie IDs
 - PropertyDefinition - boolean format
 - PropertyValue - boolean value parsing
 - PropertyValue - integer range parsing

Design decisions:
 - As discussed I adjusted the format in a way so that we can directly deserialize objects like property description from a test definition field (`defintion`)
 - I used the `type` field in the test object to distinguish between certain test data types that change the types of the other fields in the definition (with the exception of description and valid).
   - This is also the reason why there is a specific type: propertyvalueinteger. This type defines that the output_data field in the has to be a integer type which then can be used to compare the integer conversion from the string in the input_data. 
   - I am not yet sure how we can deal with color or duration type fields for this case as these have no JSON datatype representation

With this I have a fairly generic implementation I can use to execute the tests.

This also contains some corrections to the boolean test file you provided for the "space is valid" tests. (you had them on valid: false)

This is only my first suggestion. I have not tested all types of tests, so there might still a change be needed to the overall data format. The readme can still be improved and the field names might need some more refining. 
I haven't had time yet to implement further tests.