### PR TITLE
Fix float and integer tests according to specs

### DIFF
--- a/homie5/values/float.yml
+++ b/homie5/values/float.yml
@@ -62,36 +62,36 @@ tests:
     input_data: "Infinity"
     valid: false
 
-  - description: Normal integer value without format works
-    testtype: propertyvalueinteger
+  - description: Normal float value without format works
+    testtype: propertyvaluefloat
     definition:
-      datatype: integer
+      datatype: float
     input_data: "12"
     output_data: 12
     valid: true
 
   - description: Rounded step for min max bounds works
-    testtype: propertyvalueinteger
+    testtype: propertyvaluefloat
     definition:
-      datatype: integer
+      datatype: float
       format: "0:10:2"
     input_data: "9"
     output_data: 10
     valid: true
 
   - description: Rounded step for max bounds works
-    testtype: propertyvalueinteger
+    testtype: propertyvaluefloat
     definition:
-      datatype: integer
-      format: ":10:2"
-    input_data: "9"
-    output_data: 8
+      datatype: float
+      format: ":21:3"
+    input_data: "16.4"
+    output_data: 15
     valid: true
 
   - description: Rounded step for min bounds works
-    testtype: propertyvalueinteger
+    testtype: propertyvaluefloat
     definition:
-      datatype: integer
+      datatype: float
       format: "0::2"
     input_data: "9"
     output_data: 10

--- a/homie5/values/integer.yml
+++ b/homie5/values/integer.yml
@@ -13,16 +13,16 @@ tests:
     definition:
       datatype: integer
       format: "0:10:2"
-    input_data: "9"
-    output_data: 10
+    input_data: "5"
+    output_data: 6
     valid: true
   - description: Rounded step for max bounds works
     testtype: propertyvalueinteger
     definition:
       datatype: integer
       format: ":10:2"
-    input_data: "9"
-    output_data: 8
+    input_data: "5"
+    output_data: 6
     valid: true
   - description: Rounded step for min bounds works
     testtype: propertyvalueinteger


### PR DESCRIPTION
There were errors in the integer and float value tests. 
- Integer tests in the float.yaml
- wrong test spec with regards to expected result

This PR addresses them.